### PR TITLE
CI release fixes: no releases from PR builds, release notes from CHANGES.md

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,7 +36,11 @@ jobs:
         with:
           path: ./releases/*.jar
           name: Downloadable Extension File
+      # The release steps below must only run for pushes to main or early-adopter.
+      # On pull_request events the ref is not a branch, so they would wrongly
+      # use the early_adopter_ prefix and replace a release from a PR build.
       - name: Get previous tag for the branch
+        if: github.event_name == 'push'
         id: get_previous_tag
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
@@ -57,18 +61,20 @@ jobs:
               echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
           fi
       - name: Delete the previous tag
-        if: env.PREVIOUS_TAG != ''
+        if: github.event_name == 'push' && env.PREVIOUS_TAG != ''
         run: |
           gh release delete ${{ env.PREVIOUS_TAG }} -y
           git push origin --delete ${{ env.PREVIOUS_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract new version
+        if: github.event_name == 'push'
         id: get_version
         run: |
           VERSION=$(grep "^version=" src/main/resources/extension.properties | awk -F'=' '{print $2}')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Set release tag based on branch
+        if: github.event_name == 'push'
         id: vars
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
@@ -77,6 +83,7 @@ jobs:
             echo "RELEASE_TAG=early_adopter_${VERSION}" >> $GITHUB_ENV
           fi
       - name: Create Release using GitHub CLI
+        if: github.event_name == 'push'
         run: |
           gh release create ${{ env.RELEASE_TAG }} ./releases/*.jar \
             --title "Release ${{ env.RELEASE_TAG }}" \

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,14 +7,12 @@ on:
   push:
     branches:
       - main
-      - early-adopter
   pull_request:
     branches:
       - main
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.head_ref != 'early-adopter' || github.base_ref != 'main'
     runs-on: ubuntu-latest
 
     steps:
@@ -36,7 +34,7 @@ jobs:
         with:
           path: ./releases/*.jar
           name: Downloadable Extension File
-      # The release steps below must only run for pushes to main or early-adopter.
+      # The release steps below must only run for pushes to main.
       # On pull_request events the ref is not a branch, so they would wrongly
       # use the early_adopter_ prefix and replace a release from a PR build.
       - name: Get previous tag for the branch
@@ -82,12 +80,28 @@ jobs:
           else
             echo "RELEASE_TAG=early_adopter_${VERSION}" >> $GITHUB_ENV
           fi
+      - name: Build release notes from CHANGES.md
+        if: github.event_name == 'push'
+        run: |
+          # Copy the section of the released version from CHANGES.md.
+          # The heading format must be: ## Version X.Y (YYYY-MM-DD)
+          awk -v ver="$VERSION" '
+            index($0, "## Version " ver " ") == 1 {found=1; next}
+            found && /^## / {exit}
+            found {print}
+          ' CHANGES.md > release_notes.md
+
+          if [[ ! -s release_notes.md ]]; then
+            echo "This jar file has been built by GitHub automatically." > release_notes.md
+          fi
+          echo "" >> release_notes.md
+          echo "Full change history: https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGES.md" >> release_notes.md
       - name: Create Release using GitHub CLI
         if: github.event_name == 'push'
         run: |
           gh release create ${{ env.RELEASE_TAG }} ./releases/*.jar \
             --title "Release ${{ env.RELEASE_TAG }}" \
-            --notes "This jar file has been built by GitHub automatically." \
+            --notes-file release_notes.md \
             --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,24 @@
+# Change History
+
+Release notes for the Sharpener Burp Suite extension. The newest version is at the top.
+
+The CI release job copies the section of the released version into the GitHub release notes.
+Keep the heading format exactly as `## Version X.Y (YYYY-MM-DD)` so it can find the section.
+
+## Version 4.7 (2026-07-14)
+
+- The custom Burp Suite icon now also changes the Windows taskbar icon when Burp is started from its native launcher. Before this fix, it only worked when Burp was started with `java -jar`.
+- The custom Burp Suite icon now changes the macOS Dock icon as well.
+- Custom icons are applied in multiple sizes (16 to 128 pixels) for sharper rendering in taskbars, window switchers, and title bars. The original icon is fully restored on reset or unload.
+- Burp version detection now uses the Montoya `buildNumber()` value because the older version methods are deprecated and return misleading values on current Burp releases.
+- The minimum supported Burp version is now 2024.2, the first release that requires Java 21.
+- Sub-tab styling has been updated for the tab bar changes in Burp 2026.
+- Groundwork for a future message editor has been added but stays disabled by default: undo and redo, request loading, and quick copy and paste experiments.
+- A new regression test suite (over 100 headless tests) covers styles, colors, icons, version parsing, and helper classes.
+- GitHub Actions workflows have been hardened: all actions are pinned to commit SHAs and release steps only run for branch pushes.
+- The `early-adopter` branch has been retired. All development now happens through pull requests into `main`.
+
+## Version 4.5 and older
+
+Older versions were released before this file existed.
+See the [commit history](https://github.com/irsdl/BurpSuiteSharpenerEx/commits/main/) and the [releases page](https://github.com/irsdl/BurpSuiteSharpenerEx/releases).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Refer to the "Burp Suite Compatibility and Reporting Errors" section for detaile
 # Burp Suite Compatibility and Reporting Errors
 This extension targets the most recent Burp Suite release. It was last tested with the pro version 2026.4.3, the most recent stable release at the time of this documentation. It is also compatible with the community edition. The minimum supported version is Burp Suite 2024.2, as that is the first release that requires Java 21.
 
-For those keen on using the latest updates, the [early-adopter branch](https://github.com/irsdl/BurpSuiteSharpenerEx/tree/early-adopter) is available.
+All changes are released from the `main` branch. See [CHANGES.md](CHANGES.md) for the change history of each release.
 
 We actively use this extension and occasionally observe potential errors, particularly when Burp Suite updates its core functionalities or UI. As an open-source project, we heavily rely on community feedback for enhancements and bug fixes. If you encounter any issues, kindly report them on our [issues page](https://github.com/irsdl/BurpSuiteSharpenerEx/issues). Additionally, if you value our work, please consider [sponsoring](https://github.com/sponsors/irsdl) this project.
 
@@ -121,6 +121,16 @@ Perhaps the best features can be imported from different open-source extensions 
 ![images/img_8.png](images/img_8.png)
 
 ![images/img_9.png](images/img_9.png)
+
+# Contributing
+Pull requests are welcome. A few rules keep the automated release pipeline working:
+
+* All changes go through pull requests into the `main` branch (direct pushes are blocked).
+* Build with `./gradlew jar` (requires JDK 21). The test suite must pass: `./gradlew build` runs it headless.
+* New or changed behaviour must be covered by test cases in `src/test/java`. The extension cannot run outside Burp Suite, so tests use mocked Montoya interfaces and plain Swing components.
+* Releases are created automatically when a pull request that bumps the version is merged. To make a release:
+  * Bump `version` in `src/main/resources/extension.properties`. It must stay parseable as a number (for example `4.7`), because the update checker compares it numerically.
+  * Add a matching section at the top of [CHANGES.md](CHANGES.md) with the exact heading format `## Version X.Y (YYYY-MM-DD)`. CI copies that section into the GitHub release notes.
 
 # Thanks To
 * Corey Arthur [CoreyD97](https://twitter.com/CoreyD97) for https://github.com/CoreyD97/Burp-Montoya-Utilities/


### PR DESCRIPTION
## Summary
Fixes and documentation for the automatic release pipeline:

1. **Release steps only run on branch pushes.** PR builds also ran them; because a PR ref is not `refs/heads/main`, they used the `early_adopter_` prefix, deleted the latest early_adopter release and created a new one from the PR build (PR #26 created a spurious `early_adopter_4.7` this way).
2. **Meaningful release notes.** A new `CHANGES.md` file holds the change history. The release job copies the section of the released version into the GitHub release notes and links to the full history. If no section matches, it falls back to the old auto-build text plus the link. The extraction was tested locally against the 4.7 section.
3. **Contributor documentation.** The README gains a Contributing section covering the PR-into-main flow, build and test commands, and the release rules (version bump plus a matching `CHANGES.md` heading). The stale link to the removed early-adopter branch is replaced with a pointer to CHANGES.md.

Also removes the retired `early-adopter` branch from the workflow triggers.

Note: merging this re-creates the `main_4.7` release from the same source, now with proper notes, which is expected with the rolling release design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)