### PR TITLE
Detect a second live extension copy and self-unload

### DIFF
--- a/docs/how-sharpener-works.md
+++ b/docs/how-sharpener-works.md
@@ -69,12 +69,24 @@ Active vs legacy: `SubTabsListenersV2` and `SubTabsSettingsV2` are the active im
 3. Compatibility gate: if the Burp version is too old (or Community when not allowed), warn and self-unload.
 4. `furtherLoadingChecks()`:
    - `setUIParametersUsingMontoya(10)`: resolve main frame, root tabbed pane, dark mode, original title and icons. Up to 10 attempts, 500 ms apart (load stall is capped at about 5 seconds).
+   - Duplicate load detection (see below): if another live copy is already loaded, warn and self-unload without touching Burp's UI or saved settings.
    - Remove a stale Sharpener menu left by a previous quick unload if present.
+   - Publish this copy's liveness marker on Burp's root pane so later copies can detect it.
    - `allSettings = new ExtensionGeneralSettings(...)`: triggers the full settings lifecycle and capability discovery.
    - Install a `UIManager` Look-and-Feel listener (see below).
 5. Warm the icon cache on a background thread (`ResourceIconCache` for top menu and sub-tab icons) so menus open fast and the EDT never pays the first jar scan.
 6. Register capability handlers with Montoya. For each `CapabilitySettings` in `allSettings.capabilitySettingsList`, its `CapabilityGroup` list decides registration: `PROXY_REQUEST_HANDLER`, `PROXY_RESPONSE_HANDLER`, `WEBSOCKET_CREATION_HANDLER`. Each registration reflects a fresh handler instance via `Capability.createCapabilityObject(...)`.
 7. Register UI pieces gated by feature flags: context menu and top menu are on; suite tab and request/response editors are off. After registering the top menu, an `invokeLater` re-installs the menu UI delegate (fixes an unpainted menu after LaF change plus reload).
+
+### Duplicate load detection (SingleInstanceGuard)
+
+Loading Sharpener twice must not leave two menus and two copies fighting over the same Swing components and preference keys. A menu bar check alone cannot tell a stale leftover menu (a quick unload plus reload, where Burp removes the old menu only after the previous unload finishes) from a second live copy, so detection uses a liveness marker instead of the menu.
+
+- The marker is a `java.util.function.BooleanSupplier` stored as a client property on Burp's main frame root pane (`ExtensionMainClass.INSTANCE_MARKER_KEY`). Each copy has its own classloader, so only JDK types cross the boundary; the supplier reports `!sharedParameters.isUnloaded()`, which turns false the instant unload begins (`delayedTasks.stop()` is the first line of unload).
+- On load, `furtherLoadingChecks()` calls `SingleInstanceGuard.isAnotherInstanceLive(...)`. A live marker means a real second copy: the copy shows a warning, sets `isDuplicateInstance = true`, and self-unloads. `initialize()` returns early after `furtherLoadingChecks()` for a duplicate, so no handlers or UI are registered, and `unload()` returns early so it never runs the restore logic or clears the other copy's marker.
+- A dead marker (supplier returns false), a missing marker, a foreign value, or a supplier that throws all count as "no live instance", so the stale leftover menu case falls through to the existing remove-and-continue path with no false positive.
+- A non-duplicate copy publishes its own marker before loading settings and clears it on unload, but `SingleInstanceGuard.clear` only removes the marker when it is still this copy's own supplier, so a late unload of an old copy never removes a newer copy's marker. Clearing also drops the reference into the extension classloader, so an unloaded copy does not leak.
+- Covered by `SingleInstanceGuardTest`. This replaces the old menu-bar-only check that unloaded after settings were already loaded (it left a half loaded extension behind on a quick reload, which is why it was removed in 4.6).
 
 ### Look-and-Feel change forces unload without saving
 
@@ -82,7 +94,7 @@ A LaF switch would corrupt saved styles, so the listener sets `unloadWithoutSave
 
 ### Unload
 
-`extensionUnloaded()` runs: stop the shared `delayedTasks` timer first (so no delayed task fires after unload), remove the LaF listener, `allSettings.unloadSettings()` (each area restores Burp's original UI), then flush the EDT with `invokeAndWait`. Unloading must leave Burp exactly as it was found.
+`extensionUnloaded()` runs: stop the shared `delayedTasks` timer first (so no delayed task fires after unload, and so the liveness marker turns dead at once). A duplicate copy returns here without further work. Otherwise clear this copy's liveness marker, remove the LaF listener, `allSettings.unloadSettings()` (each area restores Burp's original UI), then flush the EDT with `invokeAndWait`. Unloading must leave Burp exactly as it was found.
 
 ## 4. Settings and preferences system
 

--- a/src/main/java/ninja/burpsuite/extension/sharpener/ExtensionMainClass.java
+++ b/src/main/java/ninja/burpsuite/extension/sharpener/ExtensionMainClass.java
@@ -22,20 +22,30 @@ import ninja.burpsuite.extension.sharpener.uiSelf.suiteTab.SuiteTab;
 import ninja.burpsuite.extension.sharpener.uiSelf.topMenu.TopMenu;
 import ninja.burpsuite.libs.burp.generic.BurpUITools;
 import ninja.burpsuite.libs.generic.ResourceIconCache;
+import ninja.burpsuite.libs.generic.SingleInstanceGuard;
 import ninja.burpsuite.libs.generic.UIHelper;
 
 import javax.swing.*;
 import java.awt.*;
 import java.beans.PropertyChangeListener;
 import java.net.URI;
+import java.util.function.BooleanSupplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
 public class ExtensionMainClass implements BurpExtension, ExtensionUnloadingHandler {
+    // root pane client property key for the SingleInstanceGuard liveness marker
+    public static final String INSTANCE_MARKER_KEY = "ninja.burpsuite.extension.sharpener.loadedInstance";
+
     private ExtensionSharedParameters sharedParameters = null;
     private Boolean isActive = null;
     private PropertyChangeListener lookAndFeelPropChangeListener;
+    // true when another live copy of this extension was detected, so this copy
+    // must unload itself without touching Burp's UI or the saved settings
+    private boolean isDuplicateInstance = false;
+    // this copy's own liveness marker, kept so unload removes exactly this marker
+    private BooleanSupplier ownInstanceMarker = null;
 
     @Override
     public void initialize(MontoyaApi api) {
@@ -55,6 +65,11 @@ public class ExtensionMainClass implements BurpExtension, ExtensionUnloadingHand
         }
 
         furtherLoadingChecks();
+
+        // a second live copy of the extension was detected: this copy has already asked
+        // Burp to unload it, so it must not register any handlers or UI below
+        if (isDuplicateInstance)
+            return;
 
         // load the menu icons into the cache on a short-lived background thread,
         // so neither extension loading nor the EDT pays for the first icon scan.
@@ -166,6 +181,21 @@ public class ExtensionMainClass implements BurpExtension, ExtensionUnloadingHand
                 return;
             }
 
+            // Duplicate load detection. A menu bar check cannot tell a stale leftover menu
+            // (quick unload plus reload race) from a second live copy, so a liveness marker
+            // on Burp's root pane is checked instead: the previous copy's marker turns dead
+            // as soon as its unload starts, while a genuinely loaded copy stays live.
+            JRootPane burpRootPane = sharedParameters.get_mainFrameUsingMontoya().getRootPane();
+            if (SingleInstanceGuard.isAnotherInstanceLive(burpRootPane, INSTANCE_MARKER_KEY)) {
+                isDuplicateInstance = true;
+                String errMessage = "Another live copy of the " + sharedParameters.extensionName +
+                        " extension is already loaded. This copy will now be unloaded.";
+                sharedParameters.printlnError(errMessage);
+                UIHelper.showWarningMessage(errMessage, sharedParameters.get_mainFrameUsingMontoya());
+                sharedParameters.montoyaApi.extension().unload();
+                return;
+            }
+
             // A leftover Sharpener menu can still be present right after a quick unload plus reload,
             // because Burp removes the old menu only after the previous unload has finished.
             // Our own menu is registered later, so any menu found now is stale.
@@ -175,6 +205,11 @@ public class ExtensionMainClass implements BurpExtension, ExtensionUnloadingHand
                 sharedParameters.printlnError("A leftover " + sharedParameters.extensionName + " menu was found. Removing it and continuing to load.");
                 BurpUITools.removeMenuBarByName(sharedParameters.extensionName, sharedParameters.get_mainMenuBarUsingMontoya(), true);
             }
+
+            // publish this copy's liveness marker before anything else is loaded, so a copy
+            // loaded from now on detects this one; the supplier turns false once unload starts
+            ownInstanceMarker = () -> !sharedParameters.isUnloaded();
+            SingleInstanceGuard.publish(burpRootPane, INSTANCE_MARKER_KEY, ownInstanceMarker);
 
             // This needs to be initialized after the UI is accessible
             initializeSettings();
@@ -232,6 +267,23 @@ public class ExtensionMainClass implements BurpExtension, ExtensionUnloadingHand
         sharedParameters.printDebugMessage("unload");
         // stop all delayed tasks first so nothing fires against the dead Burp API while we clean up
         sharedParameters.delayedTasks.stop();
+
+        // a duplicate copy never published a marker, never loaded settings, and never
+        // touched Burp's UI, so it must not run the restore logic of the live copy
+        if (isDuplicateInstance) {
+            sharedParameters.printDebugMessage("Duplicate copy unloaded without touching the UI.");
+            return;
+        }
+
+        // remove this copy's liveness marker so a later load never sees a dead leftover
+        // marker, and so the marker does not keep the unloaded classloader alive
+        try {
+            SingleInstanceGuard.clear(sharedParameters.get_mainFrameUsingMontoya().getRootPane(),
+                    INSTANCE_MARKER_KEY, ownInstanceMarker);
+        } catch (Exception e) {
+            sharedParameters.printDebugMessage("Could not clear the instance marker: " + e.getMessage());
+        }
+
         try {
             /*
             // reattaching related tools before working on them!

--- a/src/main/java/ninja/burpsuite/libs/generic/SingleInstanceGuard.java
+++ b/src/main/java/ninja/burpsuite/libs/generic/SingleInstanceGuard.java
@@ -1,0 +1,53 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.generic;
+
+import javax.swing.JComponent;
+import java.util.function.BooleanSupplier;
+
+// Detects a second live copy of the extension inside the same Burp process.
+// A menu bar check cannot tell "stale leftover menu after a quick reload" from
+// "a second copy is really loaded", so this guard uses a liveness marker instead.
+// The marker is a client property on a Swing component every copy can reach
+// (Burp's main frame root pane). Each extension copy has its own classloader,
+// so only JDK types cross the boundary: the marker value is a BooleanSupplier
+// (loaded by the bootstrap classloader) that reports whether its owner is still loaded.
+public class SingleInstanceGuard {
+
+    private SingleInstanceGuard() {
+    }
+
+    // True when a marker exists on the host and its owner reports it is still loaded.
+    // A missing marker, a foreign value under the key, a supplier that returns false,
+    // or a supplier that throws (its owner is half dead) all mean "no live instance".
+    public static boolean isAnotherInstanceLive(JComponent host, String markerKey) {
+        Object marker = host.getClientProperty(markerKey);
+        if (marker instanceof BooleanSupplier ownerIsLoaded) {
+            try {
+                return ownerIsLoaded.getAsBoolean();
+            } catch (Throwable e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    // Publishes this copy's liveness marker, replacing any dead leftover marker.
+    public static void publish(JComponent host, String markerKey, BooleanSupplier ownerIsLoaded) {
+        host.putClientProperty(markerKey, ownerIsLoaded);
+    }
+
+    // Removes the marker, but only when it is still this copy's own marker.
+    // Clearing must not remove a newer copy's marker, and it must always run on
+    // unload: the marker holds a reference into the extension classloader, and a
+    // leftover reference would keep the unloaded classloader alive.
+    public static void clear(JComponent host, String markerKey, BooleanSupplier ownMarker) {
+        if (ownMarker != null && host.getClientProperty(markerKey) == ownMarker) {
+            host.putClientProperty(markerKey, null);
+        }
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/generic/SingleInstanceGuardTest.java
+++ b/src/test/java/ninja/burpsuite/libs/generic/SingleInstanceGuardTest.java
@@ -1,0 +1,114 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.generic;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JPanel;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// Guards the duplicate extension load detection: a second live copy must be
+// detected, while a dead marker left by a quick unload plus reload must not
+// trigger a false positive (that false positive is why the old menu bar based
+// check was removed in version 4.6).
+public class SingleInstanceGuardTest {
+
+    private static final String KEY = "test.instanceMarker";
+    private JPanel host;
+
+    @BeforeEach
+    void setUp() {
+        host = new JPanel();
+    }
+
+    @Test
+    void noMarkerMeansNoLiveInstance() {
+        assertFalse(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void liveMarkerIsDetected() {
+        SingleInstanceGuard.publish(host, KEY, () -> true);
+        assertTrue(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void deadMarkerIsNotDetected() {
+        // the quick unload plus reload race: the marker exists but its owner is unloaded
+        SingleInstanceGuard.publish(host, KEY, () -> false);
+        assertFalse(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void throwingMarkerIsNotDetected() {
+        // a half dead owner must count as not loaded, never break the new copy's load
+        SingleInstanceGuard.publish(host, KEY, () -> {
+            throw new IllegalStateException("owner is gone");
+        });
+        assertFalse(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void foreignValueUnderTheKeyIsIgnored() {
+        host.putClientProperty(KEY, "not a marker");
+        assertFalse(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void markerTurnsDeadWhenItsRunnerStops() {
+        // the real marker is backed by DelayedTaskRunner.isStopped(), which flips
+        // as soon as unload starts, so a reloading copy never sees itself as live
+        DelayedTaskRunner runner = new DelayedTaskRunner();
+        SingleInstanceGuard.publish(host, KEY, () -> !runner.isStopped());
+        assertTrue(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+
+        runner.stop();
+        assertFalse(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void publishReplacesADeadLeftoverMarker() {
+        SingleInstanceGuard.publish(host, KEY, () -> false);
+        SingleInstanceGuard.publish(host, KEY, () -> true);
+        assertTrue(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void clearRemovesOwnMarker() {
+        BooleanSupplier ownMarker = () -> true;
+        SingleInstanceGuard.publish(host, KEY, ownMarker);
+        SingleInstanceGuard.clear(host, KEY, ownMarker);
+
+        assertNull(host.getClientProperty(KEY), "the marker must be removed so it cannot leak the classloader");
+        assertFalse(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void clearKeepsANewerCopysMarker() {
+        // an old copy unloading late must never remove the marker the new copy published
+        BooleanSupplier oldMarker = () -> false;
+        BooleanSupplier newMarker = () -> true;
+        SingleInstanceGuard.publish(host, KEY, oldMarker);
+        SingleInstanceGuard.publish(host, KEY, newMarker);
+
+        SingleInstanceGuard.clear(host, KEY, oldMarker);
+
+        assertSame(newMarker, host.getClientProperty(KEY));
+        assertTrue(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+
+    @Test
+    void clearWithNullOwnMarkerDoesNothing() {
+        // a copy that never published (for example a detected duplicate) clears nothing
+        SingleInstanceGuard.publish(host, KEY, () -> true);
+        SingleInstanceGuard.clear(host, KEY, null);
+        assertTrue(SingleInstanceGuard.isAnotherInstanceLive(host, KEY));
+    }
+}


### PR DESCRIPTION
## Problem

Loading Sharpener twice left two "Sharpener" menus and two copies fighting over the same Swing components and preference keys. The old menu-bar-only duplicate check was removed in 4.6 because it could not tell a stale leftover menu (a quick unload plus reload, where Burp removes the old menu only after the previous unload finishes) from a genuinely loaded second copy, so it false-positived on normal reloads. That removal left no duplicate detection at all.

## Fix

New `SingleInstanceGuard`: each copy publishes a `BooleanSupplier` liveness marker as a client property on Burp's main-frame root pane. The supplier reports `!isUnloaded()`, which turns dead the instant `unload()` runs (it stops the shared timer as its first line).

- On load, a copy that finds a **live** marker shows a clear warning and self-unloads before registering any handlers or UI; its `unload()` returns early so it never touches the first copy's UI, settings, or marker.
- A **dead / missing / foreign / throwing** marker (the stale-reload case) falls through to the existing remove-leftover-menu-and-continue path, so there is no false positive.
- The marker is cleared on unload, which also drops the reference into the extension classloader so an unloaded copy does not leak. `clear` only removes the marker when it is still this copy's own supplier, so a late unload of an old copy never removes a newer copy's marker.

## Testing

- `SingleInstanceGuardTest` (10 cases): live-marker detected, dead/foreign/throwing markers ignored, marker turns dead when its runner stops, clear removes own marker but keeps a newer copy's marker.
- Live in a running Burp (jdb-verified): the two-copies-in-config case now shows the warning and self-unloads, leaving exactly one Sharpener menu with the first copy fully live.
- `docs/how-sharpener-works.md` updated.

No version bump (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
