### PR TITLE
Address BApp Store automated review feedback, version 4.91

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,13 @@ Release notes for the Sharpener Burp Suite extension. The newest version is at t
 The CI release job copies the section of the released version into the GitHub release notes.
 Keep the heading format exactly as `## Version X.Y (YYYY-MM-DD)` so it can find the section.
 
+## Version 4.91 (2026-07-21)
+
+- The update check now verifies the TLS certificate of the GitHub server, so an attacker on the network cannot replace the version information. The check is still off by default and only runs when "Check for Update on Start" is enabled.
+- The tab right-click menu no longer reads the clipboard on the UI thread. When another application owned the clipboard and answered slowly, opening a tab menu could freeze the whole Burp window. The clipboard is now read in the background and the Paste Title item is enabled as soon as the value arrives.
+- The focus listener that keeps the custom Burp icon applied now skips windows that already show the icon and no longer repeats the OS taskbar and dock calls, so a window focus change does no redundant work.
+- The placeholder HTTP request editor (disabled by default) no longer adds demo headers to a request. An untouched editor returns the original request unchanged.
+
 ## Version 4.9 (2026-07-15)
 
 - The off screen window check can now also restore a Burp window that has become too small to see: it is resized to two thirds of the screen and moved to the center.

--- a/docs/how-sharpener-works.md
+++ b/docs/how-sharpener-works.md
@@ -113,7 +113,7 @@ Visibility: `GLOBAL` = Burp user preferences, shared across projects. `PROJECT` 
 
 `ExtensionGeneralSettings` composes everything. Load order: `TopMenuSettings`, `ContextMenuSettings`, (`SuiteTabSettings` if enabled), optional update check, `BurpFrameSettings`, `MainTabsSettings`, `SubTabsSettingsV2`, then `capabilityInitializer()`.
 
-Update check: gated by GLOBAL `checkForUpdate` (default false). Fetches `propertiesFileUrl` from GitHub, extracts `version=([\d.]+)`, compares both sides as `double`. This is why `version` in `extension.properties` must stay parseable as a double.
+Update check: gated by GLOBAL `checkForUpdate` (default false). Fetches `propertiesFileUrl` from GitHub through Burp networking with `RequestOptions.withUpstreamTLSVerification()` (Burp does not verify the upstream certificate otherwise), extracts `version=([\d.]+)`, compares both sides as `double`. This is why `version` in `extension.properties` must stay parseable as a double.
 
 ## 5. ExtensionSharedParameters (shared state)
 
@@ -137,7 +137,7 @@ The largest area. `SubTabsSettingsV2` (settings and persistence), `SubTabsListen
 Opened by right-click, middle-click, Alt+click on a tab, or Ctrl+Enter. Built by `SubTabsActions.createPopupMenu()` inside a `JScrollPopupMenu` (scrolls when taller than the screen). Contents:
 
 - **Rename Title** (F2), plain input dialog, titles trimmed and capped at 100 chars.
-- **Copy Title** (Ctrl+Shift+C) and **Paste Title** (Ctrl+Shift+V). Paste strips a leading `#<digits>` uniqueness prefix. The old title is kept under Previous Titles.
+- **Copy Title** (Ctrl+Shift+C) and **Paste Title** (Ctrl+Shift+V). Paste strips a leading `#<digits>` uniqueness prefix. The old title is kept under Previous Titles. The clipboard is always read on a background thread (`readClipboardTitleAsync`), never on the EDT: the clipboard owner is another process and a stuck owner would freeze the Burp UI. The Paste Title item starts disabled and is enabled when the value arrives.
 - **Previous Titles**: per-tab title history with Set, Copy, Clear History.
 - **Match/Replace Titles (RegEx)** across visible tabs.
 - **Predefined Styles**: High/Medium/Low/Info Confirmed and Unconfirmed, Interesting 1/2 (bold, fixed colors: high `#f71414`, medium `#ff7e0d`, low `#FAD400`, info `#0d9e1e`, interesting `#395EEA`, interesting2 `#D641CF`), plus icon-only styles False Positive, Duplicate, Tick, Cross.
@@ -219,7 +219,7 @@ Unload: `uninstallFromComponent()` removes only entries whose action value start
 
 - **Save**: moves and resizes are debounced (1 s / 2 s) on the shared timer, then bounds are saved to GLOBAL `lastApplicationPosition` and `lastApplicationSize`. Minimised frames are never saved (Windows reports bogus -32000 bounds when iconified; checked via `Frame.ICONIFIED`).
 - **Restore** (`useLastScreenPositionAndSize`, GLOBAL, default false): applied at load, ignoring saved positions beyond -30000 and sizes below `MIN_VISIBLE_FRAME_SIZE` (100x100), so Burp can never start invisible.
-- **Off-screen check** (`detectOffScreenPosition`, GLOBAL, default true): at load, an interactive check (10% margin) asks before recentering; at runtime after moves/resizes, a non-interactive check (80% margin) recenters with a warning. A too-small window is resized to two thirds of the screen. The check runs on the EDT and any error or open dialog cannot stall the shared timer.
+- **Off-screen check** (`detectOffScreenPosition`, GLOBAL, default true): at load, an interactive check (10% margin) asks before recentering; at runtime after moves/resizes, a non-interactive check (80% margin) recenters with a warning. A too-small window is resized to two thirds of the screen. The check runs on the EDT and any error or open dialog cannot stall the shared timer. Its dialogs use a null parent on purpose: the Burp frame is off the screen or invisible at that moment, and a dialog centered on that frame would be invisible too, so the dialog is centered on the primary screen instead.
 - **Centering**: `UIHelper.moveFrameToCenter` centers within the default screen's usable bounds (taskbar insets subtracted) and clamps so the title bar stays reachable. Geometry helpers (`isBoundsOutOfScreen`, `getCenteredLocation`, `isSizeTooSmall`) are pure and unit-tested.
 - Unload removes the listener and Sharpener key bindings; position/size preferences persist deliberately.
 
@@ -230,7 +230,7 @@ Unload: `uninstallFromComponent()` removes only entries whose action value start
 - Title: PROJECT preference `BurpTitle`, set via top menu, restored on unload from the original captured at startup.
 - Icon: PROJECT `BurpIconCustomPath` (file) wins over PROJECT `BurpResourceIconName` (bundled icon); GLOBAL `LastBurpIconCustomPath` remembers the file dialog location. The base image is scaled to 16/24/32/48/64/128 and applied to every open `Window` (covers detached tools).
 - OS integration: macOS Dock via `java.awt.Taskbar` (original saved once); Windows taskbar via `WindowsAppUserModelId`, a pure JNA COM property-store client that sets each frame's AppUserModelID to a custom ID so the taskbar shows the window icon instead of the install4j launcher icon. Empty ID restores the default. All of this is best effort, wrapped against `Exception | LinkageError`.
-- Burp rewrites window icons, so a `WindowFocusListener` on the main frame re-applies the icons on focus gained and lost. The exact listener instance is stored so unload removes only Sharpener's listener (never Burp's or another extension's).
+- Burp rewrites window icons, so a `WindowFocusListener` on the main frame re-applies the icons on focus gained and lost. The refresh is cheap: windows that already carry the icon list (compared by instance) are skipped, and the OS taskbar and dock calls only run when the applied icon actually changed (`appliedOsTaskbarIconImage`). The exact listener instance is stored so unload removes only Sharpener's listener (never Burp's or another extension's).
 - Unload restores original icons on all windows, the Dock icon, and all recorded AppUserModelIDs.
 
 ## 11. Capabilities (proxy features)
@@ -257,7 +257,7 @@ Shipped capabilities (both enabled by default, toggled from the top menu):
 - **Context menu** (`ContextMenu`): a Montoya `ContextMenuItemsProvider` for the HTTP message editor and message lists, active for Proxy, Target, and Repeater. Currently minimal (Print request / Print response to the extension output). Not to be confused with the rich tab-header menu, which lives in `SubTabsActions` (section 6); that menu appends shortcut hints via `ShortcutMappings.menuHint(...)`, preferring the header key over the global key.
 - **Disabled features** (kept in code, gated off in `extension.properties`):
   - `suiteTab` (`hasSuiteTab=false`): `SuiteTab` is an empty `JComponent` placeholder for a future Sharpener dashboard tab.
-  - `httpRequestResponseEditor` (`hasHttpRequestEditor`/`hasHttpResponseEditor` false): an experimental RSyntaxTextArea-based message editor. Working pieces: removes the shared `RTextAreaKeymap` so Burp shortcuts survive, re-installs Undo/Redo (Ctrl+Z/Y), Ctrl +/- font zoom following Burp's editor font, dark/light RSyntax theming (`RSyntaxUtils`), experimental Ctrl+Click copy and Ctrl+Alt+Click paste. Parts are still demo code (dummy headers, placeholder combo boxes).
+  - `httpRequestResponseEditor` (`hasHttpRequestEditor`/`hasHttpResponseEditor` false): an experimental RSyntaxTextArea-based message editor. Working pieces: removes the shared `RTextAreaKeymap` so Burp shortcuts survive, re-installs Undo/Redo (Ctrl+Z/Y), Ctrl +/- font zoom following Burp's editor font, dark/light RSyntax theming (`RSyntaxUtils`), experimental Ctrl+Click copy and Ctrl+Alt+Click paste. Parts are still demo code (placeholder combo boxes), but `getRequest()` is safe: an untouched editor returns the original request unchanged and an edited one returns exactly the editor content, so nothing extra can reach a target even if the flag is enabled.
 
 ## 13. Library helpers (libs/generic)
 

--- a/src/main/java/ninja/burpsuite/extension/sharpener/ExtensionMainClass.java
+++ b/src/main/java/ninja/burpsuite/extension/sharpener/ExtensionMainClass.java
@@ -9,6 +9,9 @@ package ninja.burpsuite.extension.sharpener;
 import burp.api.montoya.BurpExtension;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.extension.ExtensionUnloadingHandler;
+import burp.api.montoya.http.Http;
+import burp.api.montoya.http.RequestOptions;
+import burp.api.montoya.http.message.HttpRequestResponse;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.proxy.http.ProxyRequestHandler;
 import burp.api.montoya.proxy.http.ProxyResponseHandler;
@@ -337,13 +340,22 @@ public class ExtensionMainClass implements BurpExtension, ExtensionUnloadingHand
         System.gc(); // probably will be ignored by Java anyway!
     }
 
+    // The update check must go through Burp networking with upstream TLS verification
+    // turned on, so a network level attacker cannot substitute the remote version file.
+    // Burp does not verify the upstream certificate unless this option is set.
+    static HttpRequestResponse sendVersionCheckRequest(Http http, HttpRequest request, RequestOptions requestOptions) {
+        return http.sendRequest(request, requestOptions.withUpstreamTLSVerification());
+    }
+
     public void checkForUpdate() {
         // we need to see whether the extension is up-to-date by reading the propertiesFileUrl link
         new Thread(() -> {
             try {
                 boolean isError = true;
 
-                var buildGradleFileResponse = sharedParameters.montoyaApi.http().sendRequest(HttpRequest.httpRequestFromUrl(sharedParameters.extensionPropertiesUrl));
+                var buildGradleFileResponse = sendVersionCheckRequest(sharedParameters.montoyaApi.http(),
+                        HttpRequest.httpRequestFromUrl(sharedParameters.extensionPropertiesUrl),
+                        RequestOptions.requestOptions());
 
                 var propertiesFile = buildGradleFileResponse.response().body().getBytes();
 

--- a/src/main/java/ninja/burpsuite/extension/sharpener/uiControllers/burpFrame/BurpFrameListeners.java
+++ b/src/main/java/ninja/burpsuite/extension/sharpener/uiControllers/burpFrame/BurpFrameListeners.java
@@ -255,6 +255,11 @@ public final class BurpFrameListeners implements ComponentListener {
         String problem = tooSmall ? "too small to be seen"
                 : "at least " + (int) (offScreenMargin * 100) + "% outside the screen";
 
+        // The dialogs below use a null parent on purpose. This code runs exactly when
+        // the Burp window is off the screen or practically invisible, and a dialog is
+        // centered on its parent, so a dialog parented to that frame would be off the
+        // screen too. A null parent centers the dialog on the primary screen, which is
+        // the only place the user is guaranteed to see it.
         if (isChoice) {
             int response = UIHelper.askConfirmMessage(sharedParameters.extensionName + ": Invisible Burp Window",
                     "The Burp Suite window is " + problem + ", do you want to restore it to the center of the screen?",

--- a/src/main/java/ninja/burpsuite/extension/sharpener/uiControllers/subTabs/SubTabsActions.java
+++ b/src/main/java/ninja/burpsuite/extension/sharpener/uiControllers/subTabs/SubTabsActions.java
@@ -726,19 +726,17 @@ public class SubTabsActions {
 
         JMenuItem pasteTitleMenu = new JMenuItem("Paste Title" + ShortcutMappings.menuHint(sharedParameters, "PasteTitle"));
 
-        try {
-            String clipboardText = (String) Toolkit.getDefaultToolkit()
-                    .getSystemClipboard().getData(DataFlavor.stringFlavor);
-            sharedParameters.lastClipboardText = clipboardText.trim().replaceAll("^#\\d+\\s+", "");
-        } catch (Exception e) {
-            sharedParameters.lastClipboardText = "";
-        }
-
-        if (sharedParameters.lastClipboardText.isBlank()) {
-            pasteTitleMenu.setEnabled(false);
-        } else {
-            pasteTitleMenu.setToolTipText("Clipboard value: " + StringUtils.abbreviate(sharedParameters.lastClipboardText, 100));
-        }
+        // The item starts disabled and is enabled once the clipboard value arrives,
+        // usually before the menu is even visible. The clipboard must not be read on
+        // the EDT here: the owner of the clipboard is another process and a slow or
+        // stuck owner would freeze the whole Burp UI during menu construction.
+        pasteTitleMenu.setEnabled(false);
+        readClipboardTitleAsync(sharedParameters, clipboardTitle -> {
+            if (!clipboardTitle.isBlank()) {
+                pasteTitleMenu.setEnabled(true);
+                pasteTitleMenu.setToolTipText("Clipboard value: " + StringUtils.abbreviate(clipboardTitle, 100));
+            }
+        });
 
         pasteTitleMenu.addActionListener(e -> {
             pasteTitle(sharedParameters, currentSubTabsContainerHandler);
@@ -1743,19 +1741,41 @@ public class SubTabsActions {
         if (currentSubTabsContainerHandler == null)
             return;
 
-        try {
-            String clipboardText = (String) Toolkit.getDefaultToolkit()
-                    .getSystemClipboard().getData(DataFlavor.stringFlavor);
-            sharedParameters.lastClipboardText = clipboardText.trim().replaceAll("^#\\d+\\s+", "");
-        } catch (Exception e) {
-            sharedParameters.lastClipboardText = "";
-        }
+        // read off the EDT, then apply the title back on the EDT
+        readClipboardTitleAsync(sharedParameters, clipboardTitle -> {
+            if (!clipboardTitle.isBlank()) {
+                currentSubTabsContainerHandler.setTabTitle(clipboardTitle, true);
+                sharedParameters.allSettings.subTabsSettings.saveSettings(currentSubTabsContainerHandler);
+                sharedParameters.printDebugMessage("Title has been pasted");
+            }
+        });
+    }
 
-        if (!sharedParameters.lastClipboardText.isBlank()) {
-            currentSubTabsContainerHandler.setTabTitle(sharedParameters.lastClipboardText, true);
-            sharedParameters.allSettings.subTabsSettings.saveSettings(currentSubTabsContainerHandler);
-            sharedParameters.printDebugMessage("Title has been pasted");
+    // Reads the clipboard text on a short background thread and hands the normalised
+    // value to the consumer on the EDT. A synchronous read can block until the process
+    // that owns the clipboard responds, so it must never run on the EDT.
+    static void readClipboardTitleAsync(ExtensionSharedParameters sharedParameters, Consumer<String> onResultOnEdt) {
+        new Thread(() -> {
+            String clipboardText;
+            try {
+                clipboardText = (String) Toolkit.getDefaultToolkit()
+                        .getSystemClipboard().getData(DataFlavor.stringFlavor);
+            } catch (Exception e) {
+                clipboardText = null;
+            }
+            String normalizedTitle = normalizeClipboardTitle(clipboardText);
+            sharedParameters.lastClipboardText = normalizedTitle;
+            SwingUtilities.invokeLater(() -> onResultOnEdt.accept(normalizedTitle));
+        }, "SharpenerClipboardRead").start();
+    }
+
+    // Trims the clipboard value and removes the "#<number> " prefix that a copied
+    // numbered tab title starts with. Returns an empty string for a null value.
+    static String normalizeClipboardTitle(String clipboardText) {
+        if (clipboardText == null) {
+            return "";
         }
+        return clipboardText.trim().replaceAll("^#\\d+\\s+", "");
     }
 
     public static void renameTitle(ExtensionSharedParameters sharedParameters, ActionEvent event) {

--- a/src/main/java/ninja/burpsuite/extension/sharpener/uiSelf/httpRequestResponseEditor/ExtensionHttpRequestEditor.java
+++ b/src/main/java/ninja/burpsuite/extension/sharpener/uiSelf/httpRequestResponseEditor/ExtensionHttpRequestEditor.java
@@ -42,16 +42,13 @@ public class ExtensionHttpRequestEditor implements ExtensionProvidedHttpRequestE
      */
     @Override
     public HttpRequest getRequest() {
-        HttpRequest request;
-
+        // an untouched editor must hand the original request back unchanged;
+        // an edited one returns exactly the editor content, nothing is ever added
         if (requestEditor.isModified()) {
-            request = requestResponse.request().withAddedHeader("test1", "demo1");
-        } else {
-            request = requestResponse.request().withAddedHeader("test2", "demo2");
-            ;
+            return HttpRequest.httpRequest(requestResponse.request().httpService(),
+                    requestEditor.sharpenerMessageEditor_RTextScrollPane.getTextArea().getText());
         }
-
-        return request;
+        return requestResponse.request();
     }
 
     /**

--- a/src/main/java/ninja/burpsuite/libs/burp/generic/BurpExtensionSharedParameters.java
+++ b/src/main/java/ninja/burpsuite/libs/burp/generic/BurpExtensionSharedParameters.java
@@ -103,6 +103,8 @@ public class BurpExtensionSharedParameters {
     public final java.util.Map<Window, String> originalWindowAppIds = java.util.Collections.synchronizedMap(new java.util.WeakHashMap<>());
     public Image originalTaskbarIconImage = null; // original java.awt.Taskbar icon (macOS Dock)
     public boolean originalTaskbarIconSaved = false;
+    // last icon applied to the OS taskbar/dock; the focus refresh skips the native call when it is unchanged
+    public Image appliedOsTaskbarIconImage = null;
 
     public enum DebugLevels {
         None("Disabled", 0),

--- a/src/main/java/ninja/burpsuite/libs/burp/generic/BurpTitleAndIcon.java
+++ b/src/main/java/ninja/burpsuite/libs/burp/generic/BurpTitleAndIcon.java
@@ -75,11 +75,34 @@ public class BurpTitleAndIcon {
         if (icons == null || icons.isEmpty()) {
             return;
         }
+        boolean anyWindowUpdated = false;
         for (Window window : Window.getWindows()) {
-            window.setIconImages(icons);
+            // skip windows that already carry exactly these icons, so the focus
+            // refresh is a no-op unless Burp rewrote them or a new window appeared
+            if (!iconsAlreadyApplied(window.getIconImages(), icons)) {
+                window.setIconImages(icons);
+                anyWindowUpdated = true;
+            }
         }
         applyOsTaskbarIcon(sharedParameters, icons);
-        sharedParameters.printDebugMessage("Burp Suite icon has been updated");
+        if (anyWindowUpdated) {
+            sharedParameters.printDebugMessage("Burp Suite icon has been updated");
+        }
+    }
+
+    // True when the current icon list already holds exactly the desired images.
+    // Compared by instance: the same list is reapplied for the lifetime of one
+    // custom icon, and Window.getIconImages() returns the same Image references.
+    static boolean iconsAlreadyApplied(List<Image> currentIcons, List<Image> desiredIcons) {
+        if (currentIcons == null || currentIcons.size() != desiredIcons.size()) {
+            return false;
+        }
+        for (int i = 0; i < desiredIcons.size(); i++) {
+            if (currentIcons.get(i) != desiredIcons.get(i)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static void setIcons_noUiLock(BurpExtensionSharedParameters sharedParameters, List<Image> icons) {
@@ -109,7 +132,11 @@ public class BurpTitleAndIcon {
     // the macOS Dock (java.awt.Taskbar) and the Windows taskbar (AppUserModelID).
     private static void applyOsTaskbarIcon(BurpExtensionSharedParameters sharedParameters, List<Image> icons) {
         try {
-            if (!GraphicsEnvironment.isHeadless() && Taskbar.isTaskbarSupported()) {
+            Image largestIcon = icons.get(icons.size() - 1);
+            // the dock icon is process wide, not per window, so one successful call is
+            // enough; this guard keeps the focus refresh away from the native API
+            if (sharedParameters.appliedOsTaskbarIconImage != largestIcon
+                    && !GraphicsEnvironment.isHeadless() && Taskbar.isTaskbarSupported()) {
                 Taskbar taskbar = Taskbar.getTaskbar();
                 if (taskbar.isSupported(Taskbar.Feature.ICON_IMAGE)) {
                     if (!sharedParameters.originalTaskbarIconSaved) {
@@ -120,7 +147,8 @@ public class BurpTitleAndIcon {
                         }
                         sharedParameters.originalTaskbarIconSaved = true;
                     }
-                    taskbar.setIconImage(icons.get(icons.size() - 1)); // the largest one
+                    taskbar.setIconImage(largestIcon);
+                    sharedParameters.appliedOsTaskbarIconImage = largestIcon;
                     sharedParameters.printDebugMessage("OS taskbar/dock icon has been updated");
                 }
             }
@@ -147,6 +175,7 @@ public class BurpTitleAndIcon {
     }
 
     private static void restoreOsTaskbarIcon(BurpExtensionSharedParameters sharedParameters) {
+        sharedParameters.appliedOsTaskbarIconImage = null;
         try {
             if (sharedParameters.originalTaskbarIconSaved && !GraphicsEnvironment.isHeadless() && Taskbar.isTaskbarSupported()) {
                 Taskbar taskbar = Taskbar.getTaskbar();
@@ -180,6 +209,9 @@ public class BurpTitleAndIcon {
     }
 
     // Burp can rewrite window icons, so the icon is applied again on focus changes.
+    // Both focus events are used because new or detached windows can appear at any
+    // time, but setIcons skips windows that already have the icon, so a refresh
+    // that finds nothing to do costs no Swing or native calls.
     // The listener instance is stored so unload can remove exactly this listener,
     // even when Burp or another extension adds its own focus listener later.
     static void installIconRefreshListener(BurpExtensionSharedParameters sharedParameters, List<Image> iconList) {

--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -1,5 +1,5 @@
 name=Sharpener
-version=4.9
+version=4.91
 url=https://github.com/irsdl/BurpSuiteSharpenerEx
 issueTracker=https://github.com/irsdl/BurpSuiteSharpenerEx/issues
 copyright=Copyright (C) 2021-2026 Soroush Dalili (@irsdl)\nReleased under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files\nDeveloped by Soroush Dalili (@irsdl): https://burpsuite.ninja/

--- a/src/test/java/ninja/burpsuite/extension/sharpener/ExtensionMainClassVersionCheckTest.java
+++ b/src/test/java/ninja/burpsuite/extension/sharpener/ExtensionMainClassVersionCheckTest.java
@@ -1,0 +1,38 @@
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+
+package ninja.burpsuite.extension.sharpener;
+
+import burp.api.montoya.http.Http;
+import burp.api.montoya.http.RequestOptions;
+import burp.api.montoya.http.message.HttpRequestResponse;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+// The update check downloads a version file and can send the user to a download
+// page, so the request must verify the upstream TLS certificate. Burp skips that
+// verification unless withUpstreamTLSVerification() is set on the request options.
+public class ExtensionMainClassVersionCheckTest {
+
+    @Test
+    void versionCheckRequestEnablesUpstreamTlsVerification() {
+        Http http = mock(Http.class);
+        HttpRequest request = mock(HttpRequest.class);
+        RequestOptions baseOptions = mock(RequestOptions.class);
+        RequestOptions verifiedOptions = mock(RequestOptions.class);
+        HttpRequestResponse response = mock(HttpRequestResponse.class);
+        when(baseOptions.withUpstreamTLSVerification()).thenReturn(verifiedOptions);
+        when(http.sendRequest(request, verifiedOptions)).thenReturn(response);
+
+        assertSame(response, ExtensionMainClass.sendVersionCheckRequest(http, request, baseOptions));
+
+        verify(baseOptions).withUpstreamTLSVerification();
+        verify(http).sendRequest(request, verifiedOptions);
+        // the single argument overload would silently skip certificate verification
+        verify(http, never()).sendRequest(any(HttpRequest.class));
+    }
+}

--- a/src/test/java/ninja/burpsuite/extension/sharpener/uiControllers/subTabs/SubTabsActionsClipboardTest.java
+++ b/src/test/java/ninja/burpsuite/extension/sharpener/uiControllers/subTabs/SubTabsActionsClipboardTest.java
@@ -1,0 +1,63 @@
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+
+package ninja.burpsuite.extension.sharpener.uiControllers.subTabs;
+
+import ninja.burpsuite.extension.sharpener.ExtensionSharedParameters;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+// The clipboard read used to run synchronously on the EDT while the tab context
+// menu was being built. When another process owned the clipboard and was slow to
+// answer, the whole Burp UI froze. The read now runs on a background thread and
+// only the result is delivered on the EDT.
+public class SubTabsActionsClipboardTest {
+
+    @Test
+    void normalizeStripsTheNumberPrefixAndTrims() {
+        assertEquals("my title", SubTabsActions.normalizeClipboardTitle("  #12 my title  "));
+        assertEquals("my title", SubTabsActions.normalizeClipboardTitle("#7 my title"));
+    }
+
+    @Test
+    void normalizeKeepsTitlesWithoutASeparatedNumberPrefix() {
+        assertEquals("plain title", SubTabsActions.normalizeClipboardTitle("plain title"));
+        assertEquals("#7title", SubTabsActions.normalizeClipboardTitle("#7title"));
+        assertEquals("# 7 title", SubTabsActions.normalizeClipboardTitle("# 7 title"));
+    }
+
+    @Test
+    void normalizeTurnsNullAndBlankIntoAnEmptyString() {
+        assertEquals("", SubTabsActions.normalizeClipboardTitle(null));
+        assertEquals("", SubTabsActions.normalizeClipboardTitle("   "));
+    }
+
+    @Test
+    void asyncReadDeliversTheResultOnTheEdtAndNeverBlocksTheCaller() throws Exception {
+        ExtensionSharedParameters sharedParameters = mock(ExtensionSharedParameters.class);
+        CountDownLatch delivered = new CountDownLatch(1);
+        AtomicBoolean onEdt = new AtomicBoolean(false);
+        AtomicReference<String> received = new AtomicReference<>();
+
+        SubTabsActions.readClipboardTitleAsync(sharedParameters, value -> {
+            onEdt.set(javax.swing.SwingUtilities.isEventDispatchThread());
+            received.set(value);
+            delivered.countDown();
+        });
+
+        assertTrue(delivered.await(10, TimeUnit.SECONDS), "the clipboard result was never delivered");
+        assertTrue(onEdt.get(), "the result must be delivered on the EDT");
+        // the value depends on the environment (headless reads yield an empty string),
+        // but it is never null and always matches the stored last clipboard text
+        assertNotNull(received.get());
+        assertEquals(sharedParameters.lastClipboardText, received.get());
+    }
+}

--- a/src/test/java/ninja/burpsuite/extension/sharpener/uiSelf/httpRequestResponseEditor/ExtensionHttpRequestEditorTest.java
+++ b/src/test/java/ninja/burpsuite/extension/sharpener/uiSelf/httpRequestResponseEditor/ExtensionHttpRequestEditorTest.java
@@ -1,0 +1,37 @@
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+
+package ninja.burpsuite.extension.sharpener.uiSelf.httpRequestResponseEditor;
+
+import burp.api.montoya.http.message.HttpRequestResponse;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.ui.editor.extension.EditorCreationContext;
+import ninja.burpsuite.extension.sharpener.ExtensionSharedParameters;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+// The request editor is a disabled placeholder (hasHttpRequestEditor is false),
+// but its getRequest() used to append demo headers to the request. If the feature
+// flag is ever enabled, an untouched editor must hand the original request back
+// unchanged so nothing extra can ever reach the target server.
+public class ExtensionHttpRequestEditorTest {
+
+    @Test
+    void untouchedEditorReturnsTheOriginalRequestWithoutAddingAnything() {
+        ExtensionSharedParameters sharedParameters = mock(ExtensionSharedParameters.class);
+        EditorCreationContext creationContext = mock(EditorCreationContext.class);
+        ExtensionHttpRequestEditor editor = new ExtensionHttpRequestEditor(sharedParameters, creationContext);
+
+        HttpRequestResponse requestResponse = mock(HttpRequestResponse.class);
+        HttpRequest originalRequest = mock(HttpRequest.class);
+        when(requestResponse.request()).thenReturn(originalRequest);
+
+        editor.setRequestResponse(requestResponse);
+
+        assertSame(originalRequest, editor.getRequest());
+        verify(originalRequest, never()).withAddedHeader(anyString(), anyString());
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/burp/generic/BurpTitleAndIconTest.java
+++ b/src/test/java/ninja/burpsuite/libs/burp/generic/BurpTitleAndIconTest.java
@@ -69,6 +69,30 @@ class BurpTitleAndIconTest {
         assertEquals("ninja.burpsuite.sharpener.customicon", BurpTitleAndIcon.CUSTOM_WINDOWS_APP_ID);
     }
 
+    @Test
+    void iconsAlreadyAppliedIsTrueForTheSameImagesInOrder() {
+        List<Image> desired = List.of(squareImage(16), squareImage(32));
+        // Window.getIconImages() returns a new list holding the same Image references
+        assertTrue(BurpTitleAndIcon.iconsAlreadyApplied(new java.util.ArrayList<>(desired), desired));
+    }
+
+    @Test
+    void iconsAlreadyAppliedIsFalseForDifferentImagesOrSizes() {
+        List<Image> desired = List.of(squareImage(16), squareImage(32));
+        // equal looking but different Image instances mean Burp replaced the icons
+        assertFalse(BurpTitleAndIcon.iconsAlreadyApplied(List.of(squareImage(16), squareImage(32)), desired));
+        // a shorter, longer, or missing current list must trigger a reapply
+        assertFalse(BurpTitleAndIcon.iconsAlreadyApplied(List.of(desired.get(0)), desired));
+        assertFalse(BurpTitleAndIcon.iconsAlreadyApplied(List.of(), desired));
+        assertFalse(BurpTitleAndIcon.iconsAlreadyApplied(null, desired));
+    }
+
+    @Test
+    void iconsAlreadyAppliedIsFalseWhenTheOrderChanged() {
+        List<Image> desired = List.of(squareImage(16), squareImage(32));
+        assertFalse(BurpTitleAndIcon.iconsAlreadyApplied(List.of(desired.get(1), desired.get(0)), desired));
+    }
+
     // The main frame is mocked because a real JFrame cannot be created in a headless test
     private static BurpExtensionSharedParameters mockSharedParametersWithFrame(JFrame frame) {
         BurpExtensionSharedParameters sharedParameters = mock(BurpExtensionSharedParameters.class);


### PR DESCRIPTION
Fixes for the automated reviewer feedback on PortSwigger/extension-portal#491.

## Changes

- **Update check TLS**: the version check request now uses `RequestOptions.requestOptions().withUpstreamTLSVerification()`, so Burp validates the GitHub certificate. Still opt-in (default off) and still through Burp networking.
- **Clipboard off the EDT**: the tab menu build and the Paste Title action read the clipboard on a background thread (`readClipboardTitleAsync`); the menu item starts disabled and is enabled on the EDT once the value arrives. A slow or stuck clipboard owner can no longer freeze the Burp UI.
- **Icon refresh guards**: the focus listener refresh skips windows that already carry the icon list (compared by instance) and repeats no OS taskbar or dock native calls (`appliedOsTaskbarIconImage`). The listener stays, because Burp rewrites window icons and detached windows can appear at any time, but a refresh with nothing to do is now a no-op.
- **Placeholder request editor hardened**: `getRequest()` returns the original request unchanged when the editor is untouched, and exactly the editor content when edited. The editor stays disabled (`hasHttpRequestEditor=false`).
- **Null parent dialogs documented**: the off screen rescue dialogs keep a null parent on purpose, since the Burp frame is off the screen at that moment; a comment now records this.
- Version 4.91, CHANGES.md entry, technical reference updated.

## Testing

- Full headless suite passes; new regression tests: `ExtensionMainClassVersionCheckTest`, `SubTabsActionsClipboardTest`, `ExtensionHttpRequestEditorTest`, plus `iconsAlreadyApplied` cases in `BurpTitleAndIconTest`.
- Verified live in Burp 2026.4.3 over JDWP: the TLS-verified update check round trip succeeded; two real focus transitions fired the icon listener with zero `Window.setIconImages` calls; Paste Title was enabled by the background read in the real tab menu and applied a normalised clipboard title to the tab header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)