### PR TITLE
Add characterization tests for the preferences library

### DIFF
--- a/src/test/java/ninja/burpsuite/libs/burp/generic/ExtendedPreferencesTest.java
+++ b/src/test/java/ninja/burpsuite/libs/burp/generic/ExtendedPreferencesTest.java
@@ -1,0 +1,125 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.burp.generic;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence.uniqueName;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+// Characterizes the safe wrappers every Sharpener settings class goes through.
+public class ExtendedPreferencesTest {
+
+    private InMemoryPersistence persistence;
+    private ExtendedPreferences preferences;
+
+    @BeforeEach
+    void setUp() {
+        persistence = new InMemoryPersistence();
+        preferences = new ExtendedPreferences(persistence.montoyaApi(), new DefaultGsonProvider());
+        preferences.sharedParameters = mockSharedParameters();
+    }
+
+    // the safe methods read sharedParameters.debugLevel directly, so the mock needs a real value
+    private static BurpExtensionSharedParameters mockSharedParameters() {
+        BurpExtensionSharedParameters sharedParameters = mock(BurpExtensionSharedParameters.class);
+        sharedParameters.debugLevel = BurpExtensionSharedParameters.DebugLevels.None.getValue();
+        return sharedParameters;
+    }
+
+    @Test
+    void safeGettersReturnTheirDefaultsForUnregisteredNamesWithoutThrowing() {
+        assertEquals("", preferences.safeGetStringSetting(uniqueName("safeString")));
+        assertFalse(preferences.safeGetBooleanSetting(uniqueName("safeBoolean")));
+        assertEquals(-1, preferences.safeGetIntSetting(uniqueName("safeInt")));
+        assertEquals("fallback", preferences.safeGetSetting(uniqueName("safeDefault"), "fallback"));
+        assertNull(preferences.safeGetSetting(uniqueName("safeNull")));
+    }
+
+    @Test
+    void safeGettersReturnTheRealValuesForRegisteredNames() {
+        String stringName = uniqueName("safeRegString");
+        String booleanName = uniqueName("safeRegBoolean");
+        String intName = uniqueName("safeRegInt");
+        preferences.register(stringName, String.class, "value", Preferences.Visibility.GLOBAL);
+        preferences.register(booleanName, Boolean.TYPE, true, Preferences.Visibility.GLOBAL);
+        preferences.register(intName, Integer.TYPE, 7, Preferences.Visibility.GLOBAL);
+
+        assertEquals("value", preferences.safeGetStringSetting(stringName));
+        assertTrue(preferences.safeGetBooleanSetting(booleanName));
+        assertEquals(7, preferences.safeGetIntSetting(intName));
+        assertEquals("value", preferences.safeGetSetting(stringName, "fallback"));
+    }
+
+    @Test
+    void safeSetSettingWritesAndVerifiesARegisteredSetting() {
+        String name = uniqueName("safeSet");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+
+        preferences.safeSetSetting(name, "changed", Preferences.Visibility.GLOBAL);
+
+        assertEquals("changed", preferences.get(name));
+        assertEquals("\"changed\"", persistence.globalStore.get(name));
+    }
+
+    @Test
+    void safeSetSettingOnAnUnregisteredNameFailsSilentlyWithoutRegistering() {
+        // Characterization of the dead auto-register fallback: the code matches the old
+        // "has not been registered" message, but library commit b7faf563 throws
+        // UnmanagedSettingException saying "is not managed by this Preferences instance".
+        // The fallback therefore never runs and the call gives up after 3 tries.
+        // A follow-up change should detect the exception by type and flip these assertions.
+        String name = uniqueName("safeSetUnregistered");
+
+        assertDoesNotThrow(() -> preferences.safeSetSetting(name, "value", Preferences.Visibility.GLOBAL));
+
+        assertFalse(persistence.globalStore.containsKey(name));
+        assertFalse(preferences.getRegisteredSettings().containsKey(name));
+        assertEquals("", preferences.safeGetStringSetting(name));
+    }
+
+    @Test
+    void safeSetSettingWithNullStillPersistsTheNull() {
+        // StandardSettings.resetSettings relies on this path: the null value is saved,
+        // then the verify step trips over null.equals and the retries do nothing more
+        String name = uniqueName("safeSetNull");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+
+        assertDoesNotThrow(() -> preferences.safeSetSetting(name, null, Preferences.Visibility.GLOBAL));
+
+        assertNull(preferences.get(name));
+        assertEquals("null", persistence.globalStore.get(name));
+    }
+
+    @Test
+    void safeSetSettingRetriesAfterATransientFailure() {
+        var flakyPreferences = new ExtendedPreferences(persistence.montoyaApi(), new DefaultGsonProvider()) {
+            int remainingFailures = 1;
+
+            @Override
+            public void set(String settingName, Object value, Object eventSource) {
+                if (remainingFailures-- > 0)
+                    throw new RuntimeException("Temporary save failure");
+                super.set(settingName, value, eventSource);
+            }
+        };
+        flakyPreferences.sharedParameters = mockSharedParameters();
+        String name = uniqueName("safeSetRetry");
+        // persistDefault=false so registration does not call set() and eat the injected failure
+        flakyPreferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL, false);
+
+        flakyPreferences.safeSetSetting(name, "saved", Preferences.Visibility.GLOBAL);
+
+        assertEquals("saved", flakyPreferences.get(name));
+        assertEquals("\"saved\"", persistence.globalStore.get(name));
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/DefaultGsonProviderTest.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/DefaultGsonProviderTest.java
@@ -1,0 +1,52 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import com.coreyd97.BurpExtenderUtilities.TypeAdapter.ByteArrayToBase64TypeAdapter;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// Characterizes the gson provider wiring that Preferences relies on.
+public class DefaultGsonProviderTest {
+
+    @Test
+    void registeringATypeAdapterRebuildsTheGsonInstance() {
+        DefaultGsonProvider provider = new DefaultGsonProvider();
+        Gson before = provider.getGson();
+        assertEquals("[1,2,3]", before.toJson(new byte[]{1, 2, 3}));
+
+        provider.registerTypeAdapter(byte[].class, new ByteArrayToBase64TypeAdapter());
+
+        Gson after = provider.getGson();
+        assertNotSame(before, after);
+        assertEquals("\"AQID\"", after.toJson(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    void preferencesConstructionActivatesTheByteArrayAndAtomicIntegerAdapters() {
+        InMemoryPersistence persistence = new InMemoryPersistence();
+        DefaultGsonProvider provider = new DefaultGsonProvider();
+        new Preferences(persistence.montoyaApi(), provider);
+
+        assertEquals("\"AQID\"", provider.getGson().toJson(new byte[]{1, 2, 3}));
+        assertArrayEquals(new byte[]{1, 2, 3}, provider.getGson().fromJson("\"AQID\"", byte[].class));
+
+        // upstream quirk kept as-is: serializing an AtomicInteger also increments it and
+        // deserializing decrements, so a save/load pair cancels out; Sharpener stores no
+        // AtomicInteger settings, so this stays inert
+        AtomicInteger counter = new AtomicInteger(5);
+        assertEquals("6", provider.getGson().toJson(counter));
+        assertEquals(6, counter.get());
+        assertEquals(5, provider.getGson().fromJson("6", AtomicInteger.class).get());
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/InMemoryPersistence.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/InMemoryPersistence.java
@@ -1,0 +1,74 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.logging.Logging;
+import burp.api.montoya.persistence.PersistedObject;
+import burp.api.montoya.persistence.Persistence;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Fake Burp persistence so the preferences code can run headless.
+// The global store fakes montoyaApi.persistence().preferences() (Burp user-level store) and
+// the project store fakes montoyaApi.persistence().extensionData() (project file store).
+// Tests can read the maps directly to assert the exact stored JSON, or seed them to
+// simulate values saved by an earlier session.
+//
+// Static-state rule: the preferences library keeps registered setting names in a static
+// NameManager shared by the whole JVM, so it is NOT reset between tests. Every test must
+// use uniqueName() for each setting it registers, otherwise later tests (or later runs of
+// the same test class in one JVM) fail with a name collision.
+public final class InMemoryPersistence {
+
+    public final Map<String, String> globalStore = new LinkedHashMap<>();
+    public final Map<String, String> projectStore = new LinkedHashMap<>();
+
+    private final MontoyaApi montoyaApi;
+
+    private static final AtomicLong NAME_COUNTER = new AtomicLong();
+
+    public InMemoryPersistence() {
+        burp.api.montoya.persistence.Preferences preferencesStore = mock(burp.api.montoya.persistence.Preferences.class);
+        when(preferencesStore.getString(anyString())).thenAnswer(invocation -> globalStore.get((String) invocation.getArgument(0)));
+        doAnswer(invocation -> globalStore.put(invocation.getArgument(0), invocation.getArgument(1)))
+                .when(preferencesStore).setString(anyString(), anyString());
+        doAnswer(invocation -> globalStore.remove((String) invocation.getArgument(0)))
+                .when(preferencesStore).deleteString(anyString());
+
+        PersistedObject extensionData = mock(PersistedObject.class);
+        when(extensionData.getString(anyString())).thenAnswer(invocation -> projectStore.get((String) invocation.getArgument(0)));
+        doAnswer(invocation -> projectStore.put(invocation.getArgument(0), invocation.getArgument(1)))
+                .when(extensionData).setString(anyString(), anyString());
+        doAnswer(invocation -> projectStore.remove((String) invocation.getArgument(0)))
+                .when(extensionData).deleteString(anyString());
+
+        Persistence persistence = mock(Persistence.class);
+        when(persistence.preferences()).thenReturn(preferencesStore);
+        when(persistence.extensionData()).thenReturn(extensionData);
+
+        montoyaApi = mock(MontoyaApi.class);
+        when(montoyaApi.persistence()).thenReturn(persistence);
+        when(montoyaApi.logging()).thenReturn(mock(Logging.class));
+    }
+
+    public MontoyaApi montoyaApi() {
+        return montoyaApi;
+    }
+
+    // returns a setting name that no other test in this JVM has used
+    public static String uniqueName(String base) {
+        return base + "_" + NAME_COUNTER.incrementAndGet();
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesListenerTest.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesListenerTest.java
@@ -1,0 +1,88 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.PreferenceListener;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence.uniqueName;
+import static org.junit.jupiter.api.Assertions.*;
+
+// Characterizes the listener notifications of library commit b7faf563.
+public class PreferencesListenerTest {
+
+    private record Notification(Object source, String settingName, Object newValue) {
+    }
+
+    private InMemoryPersistence persistence;
+    private Preferences preferences;
+    private final List<Notification> notifications = new ArrayList<>();
+    private final PreferenceListener listener =
+            (source, settingName, newValue) -> notifications.add(new Notification(source, settingName, newValue));
+
+    @BeforeEach
+    void setUp() {
+        persistence = new InMemoryPersistence();
+        preferences = new Preferences(persistence.montoyaApi(), new DefaultGsonProvider());
+    }
+
+    @Test
+    void listenerFiresOnSetWithTheGivenEventSource() {
+        String name = uniqueName("listenerSet");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.addSettingListener(listener);
+
+        Object eventSource = new Object();
+        preferences.set(name, "changed", eventSource);
+
+        assertEquals(List.of(new Notification(eventSource, name, "changed")), notifications);
+
+        // without an explicit source, the Preferences instance itself is the source
+        preferences.set(name, "changedAgain");
+        assertEquals(2, notifications.size());
+        assertSame(preferences, notifications.get(1).source());
+    }
+
+    @Test
+    void resetNotifiesListenersTwice() {
+        // reset() calls set() (first notification) and then notifies again itself;
+        // callers must tolerate the duplicate
+        String name = uniqueName("listenerReset");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.set(name, "changed");
+        preferences.addSettingListener(listener);
+
+        preferences.reset(name);
+
+        assertEquals(2, notifications.size());
+        for (Notification notification : notifications) {
+            assertSame(preferences, notification.source());
+            assertEquals(name, notification.settingName());
+            assertEquals("default", notification.newValue());
+        }
+    }
+
+    @Test
+    void removedListenersAreNotNotified() {
+        String name = uniqueName("listenerRemove");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.addSettingListener(listener);
+        preferences.set(name, "first");
+        assertEquals(1, notifications.size());
+
+        preferences.removeSettingListener(listener);
+        preferences.set(name, "second");
+
+        assertEquals(1, notifications.size());
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesPersistenceFormatTest.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesPersistenceFormatTest.java
@@ -1,0 +1,145 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import com.google.gson.reflect.TypeToken;
+import ninja.burpsuite.extension.sharpener.objects.TabFeaturesObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+import static ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence.uniqueName;
+import static org.junit.jupiter.api.Assertions.*;
+
+// Golden JSON tests: they assert the EXACT strings written to the Burp stores for the
+// setting shapes Sharpener really persists. Users' saved settings (sub-tab styles, flags,
+// debug level) are stored in this format, so any drift here would lose user data on
+// upgrade. Do not update the expected strings unless a migration is shipped with them.
+public class PreferencesPersistenceFormatTest {
+
+    private static final Type TAB_FEATURES_MAP_TYPE = new TypeToken<HashMap<String, TabFeaturesObject>>() {
+    }.getType();
+
+    private InMemoryPersistence persistence;
+    private DefaultGsonProvider gsonProvider;
+    private Preferences preferences;
+
+    @BeforeEach
+    void setUp() {
+        persistence = new InMemoryPersistence();
+        gsonProvider = new DefaultGsonProvider();
+        preferences = new Preferences(persistence.montoyaApi(), gsonProvider);
+    }
+
+    @Test
+    void stringSettingIsStoredAsAQuotedJsonString() {
+        String name = uniqueName("fmtString");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+
+        preferences.set(name, "test");
+        assertEquals("\"test\"", persistence.globalStore.get(name));
+
+        preferences.set(name, "");
+        assertEquals("\"\"", persistence.globalStore.get(name));
+    }
+
+    @Test
+    void primitiveSettingsAreStoredAsBareJsonLiterals() {
+        // the debugLevel pattern from BurpExtensionSharedParameters
+        String intName = uniqueName("fmtInt");
+        preferences.register(intName, Integer.TYPE, 0, Preferences.Visibility.GLOBAL);
+        assertEquals("0", persistence.globalStore.get(intName));
+
+        // the isScrollable / mouseWheelToScroll pattern from SubTabsSettingsV2
+        String boolName = uniqueName("fmtBool");
+        preferences.register(boolName, Boolean.TYPE, false, Preferences.Visibility.GLOBAL);
+        assertEquals("false", persistence.globalStore.get(boolName));
+        preferences.set(boolName, true);
+        assertEquals("true", persistence.globalStore.get(boolName));
+
+        String doubleName = uniqueName("fmtDouble");
+        preferences.register(doubleName, Double.class, 1.5, Preferences.Visibility.GLOBAL);
+        assertEquals("1.5", persistence.globalStore.get(doubleName));
+    }
+
+    @Test
+    void nullDefaultIsStoredAsTheJsonNullLiteral() {
+        // SubTabsSettingsV2 registers its maps with a null default
+        String name = uniqueName("fmtNull");
+
+        preferences.register(name, TAB_FEATURES_MAP_TYPE, null, Preferences.Visibility.PROJECT);
+
+        assertEquals("null", persistence.projectStore.get(name));
+        assertNull(preferences.get(name));
+    }
+
+    @Test
+    void byteArrayIsStoredAsABase64JsonString() {
+        String name = uniqueName("fmtBytes");
+        preferences.register(name, byte[].class, new byte[]{1, 2, 3}, Preferences.Visibility.GLOBAL);
+
+        assertEquals("\"AQID\"", persistence.globalStore.get(name));
+    }
+
+    @Test
+    void subTabStylesMapIsStoredWithTheExactKnownJsonLayout() {
+        // mirrors the "TabFeaturesObject_Array_<tool>" settings of SubTabsSettingsV2,
+        // the highest-value stored data: users' renamed and styled sub-tabs
+        String name = uniqueName("fmtTabFeatures");
+        preferences.register(name, TAB_FEATURES_MAP_TYPE, null, Preferences.Visibility.PROJECT);
+
+        HashMap<String, TabFeaturesObject> map = new HashMap<>();
+        map.put("my tab", sampleTabFeaturesObject());
+        preferences.set(name, map);
+
+        assertEquals("{\"my tab\":{\"index\":2,\"title\":\"My Tab\",\"tfoTitle\":\"my tab\","
+                        + "\"titleHistory\":[\"Old Tab\"],\"name\":\"\",\"fontName\":\"Arial\",\"fontSize\":14.0,"
+                        + "\"isBold\":true,\"isItalic\":false,\"isCloseButtonVisible\":false,"
+                        + "\"iconResourceString\":\"star.png\",\"iconSize\":16,\"colorCode\":\"#ff0000\"}}",
+                persistence.projectStore.get(name));
+    }
+
+    @Test
+    void storedJsonRoundTripsBackToEqualObjects() {
+        HashMap<String, TabFeaturesObject> map = new HashMap<>();
+        map.put("my tab", sampleTabFeaturesObject());
+        String mapJson = gsonProvider.getGson().toJson(map, TAB_FEATURES_MAP_TYPE);
+        HashMap<String, TabFeaturesObject> reloadedMap = gsonProvider.getGson().fromJson(mapJson, TAB_FEATURES_MAP_TYPE);
+        assertEquals(map, reloadedMap);
+        assertEquals("#ff0000", reloadedMap.get("my tab").colorCode);
+
+        byte[] bytes = new byte[]{1, 2, 3};
+        assertArrayEquals(bytes, gsonProvider.getGson().fromJson(gsonProvider.getGson().toJson(bytes), byte[].class));
+
+        assertEquals("test", gsonProvider.getGson().fromJson(gsonProvider.getGson().toJson("test"), String.class));
+        assertEquals(0, gsonProvider.getGson().fromJson(gsonProvider.getGson().toJson(0), Integer.TYPE));
+    }
+
+    @Test
+    void globalAndProjectSettingsLandOnlyInTheirOwnStores() {
+        String globalName = uniqueName("fmtRoutingGlobal");
+        String projectName = uniqueName("fmtRoutingProject");
+
+        preferences.register(globalName, String.class, "globalValue", Preferences.Visibility.GLOBAL);
+        preferences.register(projectName, String.class, "projectValue", Preferences.Visibility.PROJECT);
+
+        assertTrue(persistence.globalStore.containsKey(globalName));
+        assertFalse(persistence.globalStore.containsKey(projectName));
+        assertTrue(persistence.projectStore.containsKey(projectName));
+        assertFalse(persistence.projectStore.containsKey(globalName));
+    }
+
+    private static TabFeaturesObject sampleTabFeaturesObject() {
+        return new TabFeaturesObject(2, "My Tab", new String[]{"Old Tab"}, "Arial", 14.0f,
+                true, false, false, new Color(255, 0, 0), "star.png", 16);
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesRegistrationTest.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesRegistrationTest.java
@@ -1,0 +1,143 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import com.coreyd97.BurpExtenderUtilities.UnmanagedSettingException;
+import com.coreyd97.BurpExtenderUtilities.nameManager.NameCollisionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence.uniqueName;
+import static org.junit.jupiter.api.Assertions.*;
+
+// Characterization tests for the preferences library used by every *Settings class.
+// They define the registration contract the vendored copy must keep unchanged.
+public class PreferencesRegistrationTest {
+
+    private InMemoryPersistence persistence;
+    private Preferences preferences;
+
+    @BeforeEach
+    void setUp() {
+        persistence = new InMemoryPersistence();
+        preferences = new Preferences(persistence.montoyaApi(), new DefaultGsonProvider());
+    }
+
+    @Test
+    void registerGlobalPersistsTheDefaultToTheGlobalStore() {
+        String name = uniqueName("regGlobal");
+
+        preferences.register(name, String.class, "test", Preferences.Visibility.GLOBAL);
+
+        assertEquals("\"test\"", persistence.globalStore.get(name));
+        assertFalse(persistence.projectStore.containsKey(name));
+        assertEquals("test", preferences.get(name));
+    }
+
+    @Test
+    void registerProjectPersistsTheDefaultToTheProjectStoreOnly() {
+        String name = uniqueName("regProject");
+
+        preferences.register(name, String.class, "test", Preferences.Visibility.PROJECT);
+
+        assertEquals("\"test\"", persistence.projectStore.get(name));
+        assertFalse(persistence.globalStore.containsKey(name));
+        assertEquals("test", preferences.get(name));
+    }
+
+    @Test
+    void registerVolatilePersistsNothing() {
+        String name = uniqueName("regVolatile");
+
+        preferences.register(name, String.class, "test", Preferences.Visibility.VOLATILE);
+
+        assertFalse(persistence.globalStore.containsKey(name));
+        assertFalse(persistence.projectStore.containsKey(name));
+        assertEquals("test", preferences.get(name));
+    }
+
+    @Test
+    void registerWithoutPersistDefaultLeavesTheStoreUntouched() {
+        String name = uniqueName("regNoPersist");
+
+        preferences.register(name, String.class, "test", Preferences.Visibility.GLOBAL, false);
+
+        assertFalse(persistence.globalStore.containsKey(name));
+        assertEquals("test", preferences.get(name));
+    }
+
+    @Test
+    void registerLoadsAPreviouslyStoredValueInsteadOfTheDefault() {
+        // simulates an upgrade: the store already holds a value saved by an earlier session
+        String name = uniqueName("regStored");
+        persistence.globalStore.put(name, "\"stored\"");
+
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+
+        assertEquals("stored", preferences.get(name));
+        assertEquals("\"stored\"", persistence.globalStore.get(name));
+    }
+
+    @Test
+    void registerFallsBackToTheDefaultWhenStoredJsonIsCorrupt() {
+        String name = uniqueName("regCorrupt");
+        persistence.globalStore.put(name, "{corrupt");
+
+        preferences.register(name, Integer.class, 5, Preferences.Visibility.GLOBAL);
+
+        assertEquals(5, preferences.<Integer>get(name));
+        assertEquals("5", persistence.globalStore.get(name));
+    }
+
+    @Test
+    void registeringTheSameNameTwiceThrowsNameCollision() {
+        String name = uniqueName("regDuplicate");
+        preferences.register(name, String.class, "one", Preferences.Visibility.GLOBAL);
+
+        assertThrows(NameCollisionException.class,
+                () -> preferences.register(name, String.class, "two", Preferences.Visibility.GLOBAL));
+    }
+
+    @Test
+    void unregisterRemovesTheStoredValueAndFreesTheName() {
+        String name = uniqueName("regUnregister");
+        preferences.register(name, String.class, "one", Preferences.Visibility.GLOBAL);
+        preferences.set(name, "changed");
+
+        preferences.unregister(name);
+
+        assertFalse(persistence.globalStore.containsKey(name));
+        assertThrows(UnmanagedSettingException.class, () -> preferences.get(name));
+
+        preferences.register(name, String.class, "again", Preferences.Visibility.GLOBAL);
+        assertEquals("again", preferences.get(name));
+    }
+
+    @Test
+    void typeAndRegisteredSettingsReflectRegistrations() {
+        String name = uniqueName("regMeta");
+
+        preferences.register(name, Integer.TYPE, 0, Preferences.Visibility.PROJECT);
+
+        assertEquals(Integer.TYPE, preferences.getType(name));
+        assertEquals(Preferences.Visibility.PROJECT, preferences.getRegisteredSettings().get(name));
+    }
+
+    @Test
+    void gettingOrSettingAnUnknownNameThrowsUnmanagedSetting() {
+        String name = uniqueName("regUnknown");
+
+        UnmanagedSettingException getError = assertThrows(UnmanagedSettingException.class, () -> preferences.get(name));
+        // the exact wording matters: ExtendedPreferences matches on the old
+        // "has not been registered" text, so its auto-register fallback never triggers
+        assertTrue(getError.getMessage().contains("is not managed by this Preferences instance"));
+
+        assertThrows(UnmanagedSettingException.class, () -> preferences.set(name, "value"));
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesResetTest.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesResetTest.java
@@ -1,0 +1,121 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+import static ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence.uniqueName;
+import static org.junit.jupiter.api.Assertions.*;
+
+// Characterizes reset behavior in library commit b7faf563. The Sharpener code still avoids
+// reset()/resetAll() because of a historical library bug (see StandardSettings.resetSettings
+// and BurpExtensionSharedParameters.resetAllSettings); these tests document what the current
+// code actually does, so the workarounds can be reviewed in a follow-up change.
+public class PreferencesResetTest {
+
+    private InMemoryPersistence persistence;
+    private Preferences preferences;
+
+    @BeforeEach
+    void setUp() {
+        persistence = new InMemoryPersistence();
+        preferences = new Preferences(persistence.montoyaApi(), new DefaultGsonProvider());
+    }
+
+    @Test
+    void resetRestoresTheRegisteredDefaultAndPersistsIt() {
+        String name = uniqueName("resetSingle");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.set(name, "changed");
+        assertEquals("\"changed\"", persistence.globalStore.get(name));
+
+        preferences.reset(name);
+
+        assertEquals("default", preferences.get(name));
+        assertEquals("\"default\"", persistence.globalStore.get(name));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation") // the deprecated alias is still referenced by the workaround comments
+    void deprecatedResetSettingAliasBehavesLikeReset() {
+        String name = uniqueName("resetAlias");
+        preferences.register(name, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.set(name, "changed");
+
+        preferences.resetSetting(name);
+
+        assertEquals("default", preferences.get(name));
+    }
+
+    @Test
+    void resetAllResetsEveryRegisteredSetting() {
+        String stringName = uniqueName("resetAllString");
+        String intName = uniqueName("resetAllInt");
+        preferences.register(stringName, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.register(intName, Integer.TYPE, 0, Preferences.Visibility.PROJECT);
+        preferences.set(stringName, "changed");
+        preferences.set(intName, 9);
+
+        preferences.resetAll();
+
+        assertEquals("default", preferences.get(stringName));
+        assertEquals(0, preferences.<Integer>get(intName));
+        assertEquals("\"default\"", persistence.globalStore.get(stringName));
+        assertEquals("0", persistence.projectStore.get(intName));
+    }
+
+    @Test
+    void resetGivesAFreshCopyOfAMutableDefaultNotTheSharedInstance() {
+        Type mapType = new TypeToken<HashMap<String, String>>() {
+        }.getType();
+        String name = uniqueName("resetClone");
+        HashMap<String, String> defaultMap = new HashMap<>();
+        defaultMap.put("key", "defaultValue");
+        preferences.register(name, mapType, defaultMap, Preferences.Visibility.GLOBAL);
+
+        HashMap<String, String> changedMap = new HashMap<>();
+        changedMap.put("key", "changedValue");
+        preferences.set(name, changedMap);
+        preferences.reset(name);
+
+        HashMap<String, String> afterReset = preferences.get(name);
+        assertEquals(defaultMap, afterReset);
+        assertNotSame(defaultMap, afterReset, "reset must clone the default, not hand out the registered instance");
+    }
+
+    @Test
+    void theResetWorkaroundLoopClearsValuesThroughPlainSetCalls() {
+        // mirrors BurpExtensionSharedParameters.resetAllSettings(): the workaround writes
+        // "" for String settings and null for everything else instead of calling resetAll()
+        String stringName = uniqueName("workaroundString");
+        String intName = uniqueName("workaroundInt");
+        preferences.register(stringName, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.register(intName, Integer.TYPE, 3, Preferences.Visibility.GLOBAL);
+        preferences.set(stringName, "changed");
+        preferences.set(intName, 9);
+
+        HashMap<String, Preferences.Visibility> registeredSettings = preferences.getRegisteredSettings();
+        for (String item : registeredSettings.keySet()) {
+            if (preferences.getType(item) == String.class)
+                preferences.set(item, "");
+            else
+                preferences.set(item, null);
+        }
+
+        assertEquals("", preferences.get(stringName));
+        assertNull(preferences.get(intName));
+        assertEquals("\"\"", persistence.globalStore.get(stringName));
+        assertEquals("null", persistence.globalStore.get(intName));
+    }
+}

--- a/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesRoundTripAndReloadTest.java
+++ b/src/test/java/ninja/burpsuite/libs/thirdparty/burpextenderutilities/PreferencesRoundTripAndReloadTest.java
@@ -1,0 +1,94 @@
+// Burp Suite Extension Name: Sharpener
+// Copyright (C) 2021-2026 Soroush Dalili (@irsdl)
+// Released under AGPL v3.0 with additional terms, see the LICENSE and NOTICE files
+// Developed by Soroush Dalili (@irsdl)
+// Project link: https://github.com/irsdl/BurpSuiteSharpenerEx
+
+package ninja.burpsuite.libs.thirdparty.burpextenderutilities;
+
+import com.coreyd97.BurpExtenderUtilities.DefaultGsonProvider;
+import com.coreyd97.BurpExtenderUtilities.Preferences;
+import com.coreyd97.BurpExtenderUtilities.nameManager.NameManager;
+import com.google.gson.reflect.TypeToken;
+import ninja.burpsuite.extension.sharpener.objects.TabFeaturesObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+import static ninja.burpsuite.libs.thirdparty.burpextenderutilities.InMemoryPersistence.uniqueName;
+import static org.junit.jupiter.api.Assertions.*;
+
+// Set/get round trips plus the reload scenario: a new Preferences instance over the same
+// Burp stores must load what the previous instance saved. This mirrors an extension
+// unload/reload and a Burp restart.
+public class PreferencesRoundTripAndReloadTest {
+
+    private static final Type TAB_FEATURES_MAP_TYPE = new TypeToken<HashMap<String, TabFeaturesObject>>() {
+    }.getType();
+
+    private InMemoryPersistence persistence;
+    private Preferences preferences;
+
+    @BeforeEach
+    void setUp() {
+        persistence = new InMemoryPersistence();
+        preferences = new Preferences(persistence.montoyaApi(), new DefaultGsonProvider());
+    }
+
+    @Test
+    void setThenGetReturnsTheNewValueForEachVisibility() {
+        for (Preferences.Visibility visibility : Preferences.Visibility.values()) {
+            String name = uniqueName("roundTrip" + visibility);
+            preferences.register(name, String.class, "default", visibility);
+
+            preferences.set(name, "changed");
+
+            assertEquals("changed", preferences.get(name), "visibility: " + visibility);
+            assertEquals(visibility == Preferences.Visibility.GLOBAL, persistence.globalStore.containsKey(name),
+                    "global store routing for " + visibility);
+            assertEquals(visibility == Preferences.Visibility.PROJECT, persistence.projectStore.containsKey(name),
+                    "project store routing for " + visibility);
+        }
+    }
+
+    @Test
+    void aFreshInstanceOverTheSameStoresLoadsThePreviouslySavedValues() {
+        String stringName = uniqueName("reloadString");
+        String mapName = uniqueName("reloadMap");
+
+        preferences.register(stringName, String.class, "default", Preferences.Visibility.GLOBAL);
+        preferences.set(stringName, "changed");
+
+        preferences.register(mapName, TAB_FEATURES_MAP_TYPE, null, Preferences.Visibility.PROJECT);
+        HashMap<String, TabFeaturesObject> map = new HashMap<>();
+        TabFeaturesObject savedObject = new TabFeaturesObject(1, "Styled Tab", new String[]{}, "Consolas", 12.0f,
+                false, true, false, new Color(0, 128, 255), "", 0);
+        map.put(savedObject.getTfoTitle(), savedObject);
+        preferences.set(mapName, map);
+
+        // A real reload gives the extension a fresh classloader, so the static NameManager
+        // starts empty. Release the names directly to simulate that; unregister() would
+        // also delete the stored values, which is not what happens on a reload.
+        NameManager.release(stringName);
+        NameManager.release(mapName);
+
+        Preferences reloaded = new Preferences(persistence.montoyaApi(), new DefaultGsonProvider());
+        reloaded.register(stringName, String.class, "default", Preferences.Visibility.GLOBAL);
+        reloaded.register(mapName, TAB_FEATURES_MAP_TYPE, null, Preferences.Visibility.PROJECT);
+
+        assertEquals("changed", reloaded.get(stringName));
+        HashMap<String, TabFeaturesObject> reloadedMap = reloaded.get(mapName);
+        assertNotNull(reloadedMap);
+        assertEquals(map, reloadedMap);
+        TabFeaturesObject reloadedObject = reloadedMap.get("styled tab");
+        assertEquals("Styled Tab", reloadedObject.getTitle());
+        assertEquals("Consolas", reloadedObject.fontName);
+        assertEquals(12.0f, reloadedObject.fontSize);
+        assertFalse(reloadedObject.isBold);
+        assertTrue(reloadedObject.isItalic);
+        assertEquals("#0080ff", reloadedObject.colorCode);
+    }
+}


### PR DESCRIPTION
## Summary

First step of vendoring the Burp-Montoya-Utilities preferences code (plan: PR A). No production change, no version bump.

Adds a characterization test suite that locks the behavior of the preferences subsystem of `com.github.CoreyD97:Burp-Montoya-Utilities` at commit `b7faf563`, which Sharpener uses for all its settings. The follow-up vendoring PR must pass this exact suite unchanged (only import lines may differ), turning "the vendored copy looks the same" into a real equivalence check.

## What is covered

- `InMemoryPersistence`: headless fake of the two Burp stores (`persistence().preferences()` and `persistence().extensionData()`) backed by plain maps, with a note about the library's static `NameManager` and the unique-name rule for tests.
- `PreferencesRegistrationTest`: register for GLOBAL/PROJECT/VOLATILE, persistDefault=false, upgrade simulation from pre-existing stored JSON, corrupt JSON fallback, duplicate-name collision, unregister, type and registration queries, exact wording of `UnmanagedSettingException`.
- `PreferencesPersistenceFormatTest`: golden JSON strings for the setting shapes Sharpener really stores, including the full `TabFeaturesObject` map layout of saved sub-tab styles (the upgrade-compatibility lock), byte[] Base64, and store routing.
- `PreferencesRoundTripAndReloadTest`: set/get per visibility and a fresh-instance reload over the same stores.
- `PreferencesResetTest`: reset/resetAll behavior at b7faf563 plus the reset workaround loop from `BurpExtensionSharedParameters.resetAllSettings`.
- `PreferencesListenerTest`: listener firing on set (with event source), the double notification on reset, and listener removal.
- `DefaultGsonProviderTest`: gson rebuild on adapter registration and the adapters activated by `Preferences` construction (including the inert AtomicInteger increment quirk, kept as-is).
- `ExtendedPreferencesTest`: the safe wrappers, including the currently dead auto-register fallback (message text mismatch) documented for a later fix.

## Test plan

- [x] `./gradlew test` headless, all 258 tests pass on JDK 21

🤖 Generated with [Claude Code](https://claude.com/claude-code)